### PR TITLE
Binding C-c C-o in isearch-mode-map requires Emacs 24.3

### DIFF
--- a/lisp/init-isearch.el
+++ b/lisp/init-isearch.el
@@ -6,7 +6,8 @@
   (global-set-key [remap query-replace] 'anzu-query-replace))
 
 ;; Activate occur easily inside isearch
-(define-key isearch-mode-map (kbd "C-c C-o") 'isearch-occur) ;; to match ivy conventions
+(when (maybe-require-package 'emacs "24.3")
+  (define-key isearch-mode-map (kbd "C-c C-o") 'isearch-occur)) ;; to match ivy conventions
 
 ;; DEL during isearch should edit the search string, not jump back to the previous result
 (define-key isearch-mode-map [remap isearch-delete-char] 'isearch-del-char)


### PR DESCRIPTION
Otherwise, produces error that C-c is not a prefix key.